### PR TITLE
Release/0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog
 
+#### 0.2.0
+- [fix] `Permissions::List`: rename `#merge!` to `Permissions::List#update`
+- [fix] `Permissions::List`: add original `#merge!` implementation from `bima-doorkeeper-rails`
+
 #### 0.1.0
 - initial

--- a/lib/shark/permissions/changes.rb
+++ b/lib/shark/permissions/changes.rb
@@ -24,8 +24,16 @@ module Shark
         @privileges[:new][key] = new_value
       end
 
+      # @return [Boolean]
+      # @api public
+      def empty?
+        effect.empty? && privileges.empty?
+      end
+
+      # @return [Boolean]
+      # @api public
       def present?
-        @effect.present? || privileges.present?
+        !empty?
       end
     end
   end

--- a/lib/shark/permissions/rule.rb
+++ b/lib/shark/permissions/rule.rb
@@ -62,9 +62,7 @@ module Shark
       # @return Boolean
       # @api public
       def ==(other)
-        resource == other.resource &&
-          effect == other.effect &&
-          privileges == other.privileges
+        resource == other.resource && effect == other.effect && privileges == other.privileges
       end
 
       def as_json(*_args)

--- a/lib/shark/version.rb
+++ b/lib/shark/version.rb
@@ -3,7 +3,7 @@
 module Shark
   module Permissions
     module Core
-      VERSION = '0.1.0'
+      VERSION = '0.2.0'
     end
   end
 end

--- a/spec/shark/permissions/list_spec.rb
+++ b/spec/shark/permissions/list_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Shark::Permissions::List do
         'animal::bird::blackbird': {
           resource: 'animal::bird::blackbird',
           privileges: {
-            'sing': false
+            'sing': true
           },
           title: 'Blackbird'
         },
@@ -110,7 +110,75 @@ RSpec.describe Shark::Permissions::List do
       expect(original).to eq(Fixtures.permissions_list)
     end
 
-    it 'returns merged rules' do
+    it 'returns updated rules' do
+      expect(subject).to eq(expected_list)
+    end
+
+    it 'does not track changes' do
+      subject.each { |name, rule| expect(rule.changes).to be_empty }
+    end
+  end
+
+  describe '#update' do
+    let(:original) { Fixtures.permissions_list }
+    let(:other) do
+      Shark::Permissions::List.new({
+        'animal' => {
+          resource: 'animal',
+          privileges: { 'run' => true }
+        },
+        'animal::bird::blackbird' => {
+          resource: 'animal::bird::blackbird',
+          privileges:  { 'sing' => false }
+        }
+      })
+    end
+    let(:expected_list) do
+      Shark::Permissions::List.new({
+        'animal': {
+          resource: 'animal',
+          privileges: {
+            'move': true,
+            'run': true
+          },
+          title: 'Animal'
+        },
+        'animal::bird': {
+          resource: 'animal::bird',
+          privileges: {
+            'fly': true
+          },
+          title: 'Bird'
+        },
+        'animal::bird::blackbird': {
+          resource: 'animal::bird::blackbird',
+          privileges: {
+            'sing': false
+          },
+          title: 'Blackbird'
+        },
+        'animal::cat': {
+          resource: 'animal::cat',
+          privileges: {
+            'meow': true
+          },
+          title: 'Cat'
+        },
+        'tree': {
+          resource: 'tree',
+          privileges: {
+            'move': false
+          },
+          title: 'Tree'
+        }
+      })
+    end
+
+    subject { original.update(other) }
+
+    it { is_expected.to be(original) }
+
+    it 'returns updated rules' do
       expect(subject).to eq(expected_list)
     end
 


### PR DESCRIPTION
- [fix] `Permissions::List`: rename `#merge!` to `Permissions::List#update`
- [fix] `Permissions::List`: add original `#merge!` implementation from `bima-doorkeeper-rails`